### PR TITLE
为DependencyContainer添加了反注册方法(destroy)，并添加了一部分注释方便开发

### DIFF
--- a/kirara_ai/ioc/container.py
+++ b/kirara_ai/ioc/container.py
@@ -8,11 +8,34 @@ current_container = contextvars.ContextVar("current_container", default=None)
 
 
 class DependencyContainer:
+    """
+    作用域容器，提供依赖注册和解析的核心功能。你可以在此获取一些系统的对象
+
+    Attributes:
+        parent (DependencyContainer): 父容器实例，用于支持作用域嵌套
+        registry (dict): 存储当前容器注册的值或对象实例，格式为{key: value|object}
+
+        docs: https://docs.python.org/zh-cn/3.13/library/contextvars.html#module-contextvars
+
+    Methods:
+        register: 向容器注册一个key-value对
+        resolve: 从容器解析获取一个值或对象实例
+        destroy: 从容器中移除一个值或对象实例
+        scoped: 创建一个新的作用域容器
+    """
     def __init__(self, parent=None):
         self.parent = parent  # 父容器，用于支持作用域嵌套
         self.registry = {}  # 当前容器的注册表
 
     def register(self, key, value):
+        """
+        向容器注册一个值或者实例。
+
+
+        Args:
+            key: 对象的标识键, 为字典的键类型通常为一个字符串
+            value: 值/对象实例
+        """
         self.registry[key] = value
 
     @overload
@@ -22,7 +45,19 @@ class DependencyContainer:
     def resolve(self, key: Any) -> Any: ...
 
     def resolve(self, key: Type[T] | Any) -> T | Any:
-        # 先在当前容器中查找，如果没有则递归查找父容器
+        """
+        依照{key}从容器获取一个值或对象实例。
+        如果{key}在当前容器中不存在，则会递归查找父容器。
+
+        Args:
+            key: 对象的标识键
+
+        Returns:
+            值/对象实例
+
+        Raises:
+            KeyError: {key}在当前容器和父容器中都不存在时抛出
+        """
         if key in self.registry:
             return self.registry[key]
 
@@ -30,6 +65,28 @@ class DependencyContainer:
             return self.parent.resolve(key)
         else:
             raise KeyError(f"Dependency {key} not found.")
+
+    @overload
+    def destroy(self, key: Type[T]) -> None: ...
+
+    @overload
+    def destroy(self, key: Any) -> None: ...
+
+    def destroy(self, key: Type[T] | Any) -> None:
+        """
+        从容器中移除一个值或对象实例。
+
+        Args:
+            key: 对象的标识键
+        Raises:
+            KeyError: {key}在当前容器和父容器中都不存在时抛出
+        """
+        if key in self.registry:
+            del self.registry[key]
+        elif self.parent:
+            self.parent.destroy(key)
+        else: 
+            raise KeyError(f"Cannot destroy dependency {key} which is not found in registry or parent container's registry.")
 
     def scoped(self):
         """创建一个新的作用域容器"""


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

增强 DependencyContainer 类，添加 destroy 方法并改进文档

增强功能：
- 添加了一个新的 destroy 方法，用于从容器中移除已注册的依赖项
- 改进了类和方法的文档，提供了详细的文档字符串 (docstrings)

文档：
- 为 DependencyContainer 类添加了全面的文档，解释了其目的、属性和方法
- 为 register、resolve 和 destroy 方法包含了详细的文档字符串 (docstrings)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the DependencyContainer class by adding a destroy method and improving documentation

Enhancements:
- Added a new destroy method to remove registered dependencies from the container
- Improved class and method documentation with detailed docstrings

Documentation:
- Added comprehensive documentation for the DependencyContainer class, explaining its purpose, attributes, and methods
- Included detailed docstrings for register, resolve, and destroy methods

</details>